### PR TITLE
Fix composite punishments not being detected

### DIFF
--- a/src/main/java/net/playeranalytics/extension/libertybans/LibertyBansExtension.java
+++ b/src/main/java/net/playeranalytics/extension/libertybans/LibertyBansExtension.java
@@ -35,6 +35,7 @@ import com.djrapitops.plan.extension.icon.Icon;
 import com.djrapitops.plan.query.QueryService;
 import space.arim.libertybans.api.*;
 import space.arim.libertybans.api.punish.Punishment;
+import space.arim.libertybans.api.select.SelectionPredicate;
 import space.arim.libertybans.api.select.SortPunishments;
 import space.arim.omnibus.Omnibus;
 import space.arim.omnibus.OmnibusProvider;
@@ -52,7 +53,8 @@ public class LibertyBansExtension implements DataExtension {
 
     private LibertyBans api;
 
-    public LibertyBansExtension() {}
+    public LibertyBansExtension() {
+    }
 
     @Override
     public CallEvents[] callExtensionMethodsOn() {
@@ -76,7 +78,12 @@ public class LibertyBansExtension implements DataExtension {
         return api()
                 .getSelector()
                 .selectionBuilder()
-                .victim(PlayerVictim.of(playerUUID))
+                .victims(
+                        SelectionPredicate.matchingAnyOf(
+                                PlayerVictim.of(playerUUID),
+                                CompositeVictim.of(playerUUID, CompositeVictim.WILDCARD_ADDRESS)
+                        )
+                )
                 .type(type)
                 .build()
                 .getFirstSpecificPunishment(SortPunishments.LATEST_END_DATE_FIRST)

--- a/src/main/java/net/playeranalytics/extension/libertybans/LibertyBansListener.java
+++ b/src/main/java/net/playeranalytics/extension/libertybans/LibertyBansListener.java
@@ -1,6 +1,7 @@
 package net.playeranalytics.extension.libertybans;
 
 import com.djrapitops.plan.extension.Caller;
+import space.arim.libertybans.api.CompositeVictim;
 import space.arim.libertybans.api.PlayerVictim;
 import space.arim.libertybans.api.Victim;
 import space.arim.libertybans.api.event.PostPardonEvent;
@@ -38,6 +39,8 @@ public class LibertyBansListener {
         Victim victim = punishment.getVictim();
         if (victim instanceof PlayerVictim) {
             caller.updatePlayerData(((PlayerVictim) victim).getUUID(), null);
+        }   else if (victim instanceof CompositeVictim) {
+            caller.updatePlayerData(((CompositeVictim) victim).getUUID(), null);
         }
     }
 }


### PR DESCRIPTION
Currently, this extension does not detect any composite punishments. Servers that always use composite punishments, as supported by LibertyBans, thus don't have any LibertyBans data recognized by the extension.
This fixes the issue.